### PR TITLE
feat: print line numbers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,8 +25,9 @@ import { processSources } from './processor';
     warnings.forEach(({ location, messages }) => {
         console.warn(location);
         messages.forEach(message => {
-            console.warn('  ' + message);
+            console.warn(`  ${message}`);
         });
+        console.warn();
     });
 })().catch(console.error);
 

--- a/test/processor.test.ts
+++ b/test/processor.test.ts
@@ -10,7 +10,7 @@ describe('processSources', () => {
             const warnings = await processSources(sources);
             expect(warnings).toEqual([
                 {
-                    location: 'sample-data/LibrarySample.sol:StringUtils:nothing',
+                    location: "sample-data/LibrarySample.sol:5\nStringUtils:nothing",
                     messages: ['Natspec is missing']
                 },
             ]);


### PR DESCRIPTION
Finding the missing natspec was annoying so I came up with a way to print the exact line numbers of the function/event/error etc, which lead the user straight to the crime scene

![Screenshot 2024-01-10 at 05 19 58](https://github.com/defi-wonderland/natspec-smells/assets/86567384/57f7c075-a48f-45f2-8c33-66ed96bc8163)
