### PR TITLE
docs: update readme so example npx run finds files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Want to quickly check if your natspec smells?
 Just run:
 
 ```
-npx @defi-wonderland/natspec-smells --include src --exclude "src/**/*.sol" "(test|scripts)/**/*.sol"
+npx @defi-wonderland/natspec-smells --include "src/**/*.sol"
 ```
 
 > [!NOTE]


### PR DESCRIPTION
closes #58 

decided to remove the 'exclude' part, since the most typical usecase is Foundry projects, where tests and scripts live outside `src`